### PR TITLE
Update dokujclient (macOS compat)

### DIFF
--- a/src/main/resources/dokujclient
+++ b/src/main/resources/dokujclient
@@ -1,5 +1,7 @@
 #!/bin/bash
-if [ -L "$0" ] && [ -x $(which readlink) ]; then
+if [ -L "$0" ] && [ -x $(which greadlink) ]; then
+  thisFile="$(greadlink -mn "$0")"
+elif [ -L "$0" ] && [ -x $(which readlink) ]; then
   thisFile="$(readlink -mn "$0")"
 else
   thisFile="$0"


### PR DESCRIPTION
We should use greadlink for proper readlink operation on macOS since readlink "-m" parameter doesn't exists on macOS.
greadlink is available on "coreutils" package from Homebrew.